### PR TITLE
Support TLS connection to RabbitMQ

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ below in parentheses. Environment variables override file settings.
     loglevel = "debug"    # log level [debug|info|warn|error|fatal|panic] (GRACC_LOGLEVEL)
     
     [AMQP]
+    scheme = "amqp"       # AMQP URI scheme [amqp|amqps] (GRACC_AMQP_SCHEME)
     host = "localhost"    # AMQP broker (GRACC_AMQP_HOST)
     port = "5672"         # (GRACC_AMQP_PORT)
     vhost = ""            # (GRACC_AMQP_VHOST)
@@ -55,6 +56,10 @@ See `sample/gracc.logrotate` for a sample logrotate configuration. Copy the file
 appropriate changes) to `/etc/logrotate.d/gracc`.
 
 # Release Notes
+
+### v1.1.1
+
+Add configurable AMQP scheme to support TLS connections to broker.
 
 ### v1.1.0
 

--- a/amqp.go
+++ b/amqp.go
@@ -14,6 +14,7 @@ import (
 type AMQPConfig struct {
 	Host          string        `env:"HOST"`
 	Port          string        `env:"PORT"`
+	Scheme        string        `env:"SCHEME"`
 	Vhost         string        `env:"VHOST"`
 	User          string        `env:"USER"`
 	Password      string        `env:"PASSWORD"`
@@ -29,6 +30,9 @@ type AMQPConfig struct {
 }
 
 func (c *AMQPConfig) Validate() error {
+	if c.Scheme == "" {
+		c.Scheme = "amqp"
+	}
 	var err error
 	c.RetryDuration, err = time.ParseDuration(c.Retry)
 	return err
@@ -44,7 +48,7 @@ type AMQPOutput struct {
 func InitAMQP(conf AMQPConfig) (*AMQPOutput, error) {
 	var a = &AMQPOutput{
 		Config: conf,
-		URI: "amqp://" + conf.User + ":" + conf.Password + "@" +
+		URI: conf.Scheme + "://" + conf.User + ":" + conf.Password + "@" +
 			conf.Host + ":" + conf.Port + "/" + conf.Vhost,
 	}
 	if err := a.setup(); err != nil {

--- a/collector_test.go
+++ b/collector_test.go
@@ -21,6 +21,7 @@ var (
 		AMQP: AMQPConfig{
 			Host:         "localhost",
 			Port:         "5672",
+			Scheme:       "amqp",
 			User:         "guest",
 			Password:     "guest",
 			Format:       "json",

--- a/config.go
+++ b/config.go
@@ -31,6 +31,7 @@ func DefaultConfig() *CollectorConfig {
 		AMQP: AMQPConfig{
 			Host:         "localhost",
 			Port:         "5672",
+			Scheme:       "amqp",
 			Format:       "json",
 			User:         "guest",
 			Password:     "guest",

--- a/gracc-collector.spec
+++ b/gracc-collector.spec
@@ -1,5 +1,5 @@
 Name:           gracc-collector
-Version:        1.1.0
+Version:        1.1.1
 Release:        1%{?dist}
 Summary:        Gratia-compatible collector for grid accounting records
 License:        MIT
@@ -67,6 +67,9 @@ getent passwd gracc >/dev/null || \
 exit 0
 
 %changelog
+* Mon Jan 30 2017 Kevin Retzke <kretzke@fnal.gov> - 1.1.1-1
+- Package v1.1.1. Support AMQP+TLS.
+
 * Thu Jan 12 2017 Kevin Retzke <kretzke@fnal.gov> - 1.1.0-1
 - Package v1.1.0. Accept UsageRecord.
 

--- a/gracc.cfg
+++ b/gracc.cfg
@@ -5,6 +5,7 @@ loglevel = "debug"
 [AMQP]
 host = "localhost"
 port = "5672"
+scheme = "amqp"
 vhost = ""
 exchange = "gracc"
 durable = true

--- a/main.go
+++ b/main.go
@@ -13,7 +13,7 @@ import (
 
 // build parameters
 var (
-	build_ver  = "1.1.0"
+	build_ver  = "1.1.1"
 	build_date = "???"
 	build_ref  = "scratch"
 )


### PR DESCRIPTION
The change allows the URI scheme to be specified; if `amqps` the connection will use TLS.