### PR TITLE
Unlock mutex while waiting to retry connection. Fixes GRACC-78

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,11 @@ below in parentheses. Environment variables override file settings.
 
 # Usage
 
-    gracc-collector -c <config file> -l <log file>
+    gracc-collector [-c <config file>] [-l <log file>] [-pprof on|<address:port>]
 
-Where `<log file>` can be "stdout", "stderr", or a file name.
+Where `<log file>` can be "stdout", "stderr", or a file name; default is "stderr".
+`-pprof on` will expose [pprof](https://blog.golang.org/profiling-go-programs) on the main http server at `/debug/pprof/`. 
+`-pprof <address:port>` will expose it on a separate http server as specified, also at `/debug/pprof/`.
 
 See `sample/gracc.service` for a sample systemd unit configuration. Copy the file (with 
 appropriate changes) to `/usr/lib/systemd/system/` then use standard systemd commands to

--- a/amqp.go
+++ b/amqp.go
@@ -87,6 +87,7 @@ func (a *AMQPOutput) setup() error {
 	defer a.m.Unlock()
 	if a.connection != nil {
 		a.connection.Close()
+		a.connection = nil
 	}
 	log.WithFields(log.Fields{
 		"user":  a.Config.User,
@@ -104,7 +105,9 @@ func (a *AMQPOutput) setup() error {
 			"error": err,
 			"retry": a.Config.Retry,
 		}).Error("AMQP: error connecting to RabbitMQ")
+		a.m.Unlock()
 		time.Sleep(a.Config.RetryDuration)
+		a.m.Lock()
 	}
 	log.Info("AMQP: connection established")
 	// listen for close events


### PR DESCRIPTION
This allows any new workers that are trying to open a new channel a chance to acquire the lock and find out that the connection is not open. This will keep goroutines from piling up while rabbitmq is down.