### PR TITLE
Don't skip closing the channel when blocked

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ docker:
 
 docker-scratch:
 	CGO_ENABLED=0 GOOS=linux go build -a -tags netgo -ldflags "-X main.build_date=`date -u +%Y%m%d.%H%M%S` -X main.build_ref=RELEASE -w" -o gracc-collector
-	docker build -t opensciencegrid/gracc-collector:scratch .
+	docker build -t opensciencegrid/gracc-collector:scratch -f Dockerfile.scratch .
 
 with-docker: | docker-setup docker-build docker-rpmtest docker-clean
 

--- a/README.md
+++ b/README.md
@@ -59,6 +59,10 @@ appropriate changes) to `/etc/logrotate.d/gracc`.
 
 # Release Notes
 
+### v1.1.4
+
+* Fix issue causing collector to never see AMQP unblock signal.
+
 ### v1.1.3
 
 * Better handling of AMQP connection blocking: If the connection is blocked 

--- a/gracc-collector.spec
+++ b/gracc-collector.spec
@@ -1,5 +1,5 @@
 Name:           gracc-collector
-Version:        1.1.3
+Version:        1.1.4
 Release:        1%{?dist}
 Summary:        Gratia-compatible collector for grid accounting records
 License:        MIT
@@ -67,6 +67,9 @@ getent passwd gracc >/dev/null || \
 exit 0
 
 %changelog
+* Thu Mar 30 2017 Kevin Retzke <kretzke@fnal.gov> - 1.1.4-1
+- Package v1.1.4. Fix catching AMQP unblock signal.
+
 * Sat Feb 25 2017 Kevin Retzke <kretzke@fnal.gov> - 1.1.3-1
 - Package v1.1.3. Better handle AMQP blocked connections.
 

--- a/main.go
+++ b/main.go
@@ -14,7 +14,7 @@ import (
 
 // build parameters
 var (
-	build_ver  = "1.1.3"
+	build_ver  = "1.1.4"
 	build_date = "???"
 	build_ref  = "scratch"
 )


### PR DESCRIPTION
This was causing us to never see the unblock signal,
requiring a restart to start accepting records again.

The blocked worker will hang around until the connection is
unblocked, but new ones still won't be started.