### PR TITLE
Reset blocked flag if RabbitMQ connection is closed

### DIFF
--- a/amqp.go
+++ b/amqp.go
@@ -148,6 +148,7 @@ func (a *AMQPOutput) setup() error {
 		}
 	}()
 	// listen for blocking events
+	a.isBlocked = false
 	blockings := a.connection.NotifyBlocked(make(chan amqp.Blocking))
 	go func() {
 		for b := range blockings {

--- a/gracc-collector.spec
+++ b/gracc-collector.spec
@@ -1,5 +1,5 @@
 Name:           gracc-collector
-Version:        1.1.4
+Version:        1.1.5
 Release:        1%{?dist}
 Summary:        Gratia-compatible collector for grid accounting records
 License:        MIT
@@ -67,6 +67,9 @@ getent passwd gracc >/dev/null || \
 exit 0
 
 %changelog
+* Wed Apr 05 2017 Kevin Retzke <kretzke@fnal.gov> - 1.1.5-1
+- Package v1.1.5. Reset blocked flag if RabbitMQ connection is closed.
+
 * Thu Mar 30 2017 Kevin Retzke <kretzke@fnal.gov> - 1.1.4-1
 - Package v1.1.4. Fix catching AMQP unblock signal.
 

--- a/main.go
+++ b/main.go
@@ -14,7 +14,7 @@ import (
 
 // build parameters
 var (
-	build_ver  = "1.1.4"
+	build_ver  = "1.1.5"
 	build_date = "???"
 	build_ref  = "scratch"
 )


### PR DESCRIPTION
Another entry in the saga of ongoing woes trying to ensure reliable communication with RabbitMQ... (this one's all my fault though).

Going to let this run on ITB for a bit before merging. 