### PR TITLE
Adding forwarded address support

### DIFF
--- a/collector.go
+++ b/collector.go
@@ -163,9 +163,9 @@ func (g *GraccCollector) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	var remoteAddr string
 
 	// Check for forwarded headers
-	if remote, ok := r.Header["X-Real-IP"]; ok {
+	if remote := r.Header.Get("X-Real-IP"); remote != "" {
 		remoteAddr = remote
-	} else if remote, ok := r.Header["X-Forwarded-For"]; ok {
+	} else if remote := r.Header.Get("X-Forwarded-For"); remote != "" {
 		remoteAddr = remote
 	} else {
 		remoteAddr = r.RemoteAddr

--- a/collector.go
+++ b/collector.go
@@ -160,11 +160,22 @@ type Request struct {
 
 func (g *GraccCollector) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	g.Events <- GOT_REQUEST
+	var remoateAddr string
+
+	// Check for forwarded headers
+	if remote, ok := r.Header["X-Real-IP"]; ok {
+		remoteAddr = remote
+	} else if remote, ok := r.Header["X-Forwarded-For"]; ok {
+		remoteAddr = remote
+	} else {
+		remoteAddr = r.RemoteAddr
+	}
+
 	req := &Request{
 		w: w,
 		r: r,
 		log: log.WithFields(log.Fields{
-			"address":  r.RemoteAddr,
+			"address":  remoteAddr,
 			"length":   r.ContentLength,
 			"agent":    r.UserAgent(),
 			"url_path": r.URL.EscapedPath(),

--- a/collector.go
+++ b/collector.go
@@ -160,7 +160,7 @@ type Request struct {
 
 func (g *GraccCollector) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	g.Events <- GOT_REQUEST
-	var remoateAddr string
+	var remoteAddr string
 
 	// Check for forwarded headers
 	if remote, ok := r.Header["X-Real-IP"]; ok {


### PR DESCRIPTION
Log the correct remote address by looking at the X-Real-IP or
X-Forwarded-For headers.  If they exist, then use those for the remote
address.  Otherwise use the normal RemoteAddr from the Header.

Fixes #17