### PR TITLE
Fixup docker-compose.

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -14,12 +14,14 @@ services:
         - GRACC_AMQP_HOST=rabbitmq
         - GRACC_AMQP_EXCHANGE=gracc.osg.raw
         - GRACC_LOGLEVEL=debug
+        - GRACC_AMQP_DURABLE=true
+        - GRACC_AMQP_AUTODELETE=false
         ports:
         - "8080:8080"
         depends_on:
         - rabbitmq
     gracc-stash-raw:
-        image: retzkek/gracc-stash-raw:debug
+        image: opensciencegrid/gracc-stash-raw
         environment:
         - GRACC_INSTANCE=test
         - GRACC_STREAM=osg


### PR DESCRIPTION
Fixes two small issues in the docker-compose:
- RabbitMQ image seems to choke on our default settings for durability and auto-delete.  Flipping this in order to move forward.
- Switch from developer container for the logstash configuration to the official one.